### PR TITLE
implemented kafka handler

### DIFF
--- a/rgts-python-api/Pipfile
+++ b/rgts-python-api/Pipfile
@@ -11,6 +11,7 @@ grpcio-tools = "*"
 kafka-python = "*"
 crython = "*"
 six = "*"
+dotenv = "*"
 
 [dev-packages]
 

--- a/rgts-python-api/Pipfile.lock
+++ b/rgts-python-api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0574ff19c74a5f0a44fc3b6286e4857e1c4dcc2ef4049d6f13b64023db40681d"
+            "sha256": "e321c747064341dbfa67db55f97492b3bbf4d5c23eec159b09fc819c888f492c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -138,6 +138,13 @@
             ],
             "index": "pypi",
             "version": "==0.2.0"
+        },
+        "dotenv": {
+            "hashes": [
+                "sha256:29cf74a087b31dafdb5a446b6d7e11cbce8ed2741540e2339c69fbef92c94ce9"
+            ],
+            "index": "pypi",
+            "version": "==0.9.9"
         },
         "grpcio": {
             "hashes": [
@@ -287,6 +294,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==5.29.3"
+        },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca",
+                "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.0.1"
         },
         "requests": {
             "hashes": [

--- a/rgts-python-api/src/config.py
+++ b/rgts-python-api/src/config.py
@@ -1,0 +1,10 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class Config:
+    @staticmethod
+    def get(key, default=None):
+        return os.getenv(key, default)

--- a/rgts-python-api/src/kafka/KafkaHandler.py
+++ b/rgts-python-api/src/kafka/KafkaHandler.py
@@ -1,0 +1,76 @@
+import logging
+from collections import deque
+
+import crython
+from kafka import KafkaProducer
+
+from src.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class KafkaHandler:
+    _message_cache = deque(maxlen=1000)
+    _producer = None
+    _bootstrap_server = Config.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9093")
+
+    @classmethod
+    def get_producer(cls):
+        """Initializes Kafka Producer if not already initialized."""
+        if cls._producer is None:
+            try:
+                cls._producer = KafkaProducer(bootstrap_servers=[cls._bootstrap_server])
+                logger.info("Kafka producer initialized successfully")
+            except Exception as e:
+                logger.error(f"Failed to initialize Kafka producer: {e}")
+                cls._producer = None
+        return cls._producer
+
+    @classmethod
+    def retry_failed_messages(cls):
+        """Attempts to resend cached messages."""
+        producer = cls.get_producer()
+
+        if not producer or not cls._message_cache:
+            return
+
+        while cls._message_cache:
+            topic, message = cls._message_cache.popleft()
+            try:
+                future = producer.send(topic, message)
+                future.get(timeout=10)
+                logger.info(f"Retried message sent to {topic} successfully")
+            except Exception as e:
+                logger.error(f"Retry failed for {topic}: {e}. Adding back to cache.")
+                cls._message_cache.appendleft((topic, message))
+                break
+
+    def send_message(self, topic: str, message: bytes, delete_cached: bool = False) -> None:
+        """Attempts to send a message to Kafka. If it fails, caches the message for retry."""
+        producer = self.get_producer()
+        if producer:
+            try:
+                future = producer.send(topic, message)
+                future.get(timeout=10)
+                logger.info(f"Message sent to {topic} successfully")
+                if delete_cached:
+                    # Remove all caches messages with a specific topic (usually outdated live prices)
+                    logger.info(f"Deleting cached message for {topic}")
+                    KafkaHandler._message_cache = deque(
+                        ((t, _) for t, _ in KafkaHandler._message_cache if t != topic),
+                        maxlen=KafkaHandler._message_cache.maxlen
+                    )
+            except Exception as e:
+                logger.error(f"Failed to send message to {topic}: {e}")
+                KafkaHandler._message_cache.append((topic, message))
+        else:
+            logger.error("Kafka producer is not initialized. Message not sent.")
+            KafkaHandler._message_cache.append((topic, message))
+
+
+@crython.job(expr='@minutely')
+def schedule_retry():
+    KafkaHandler.retry_failed_messages()
+
+
+crython.start()


### PR DESCRIPTION
- Implemented an encapsulated Kafka producer
- Able to set Kafka bootstrap server via .env variable or it defaults to `localhost:9093`
- Any error sending messages will result in a cache
- Cron job runs every minute to retry sending of failed messages
- Able to clear cached messages based on topic to prevent old data being sent, useful when it comes to live price updates